### PR TITLE
Admin Button hack working in iOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,9 +17,9 @@ jobs:
           - name: macOS
             os: macos-latest
 
-          # - name: iOS
-          #   os: macos-latest
-          #   target: iOS
+          - name: iOS
+            os: macos-latest
+            target: iOS
 
           - name: Android32
             os: ubuntu-latest

--- a/src/hooks/more_options_layer.cpp
+++ b/src/hooks/more_options_layer.cpp
@@ -1,6 +1,7 @@
 #include <defs/platform.hpp>
 
 #ifdef GEODE_IS_ANDROID
+#ifndef GEODE_IS_IOS
 
 #include "more_options_layer.hpp"
 

--- a/src/hooks/more_options_layer.cpp
+++ b/src/hooks/more_options_layer.cpp
@@ -1,8 +1,5 @@
 #include <defs/platform.hpp>
 
-#ifdef GEODE_IS_ANDROID
-#ifndef GEODE_IS_IOS
-
 #include "more_options_layer.hpp"
 
 #include <ui/menu/admin/admin_login_popup.hpp>
@@ -45,5 +42,3 @@ void HookedMoreOptionsLayer::goToPage(int page) {
         m_fields->adminBtn->setVisible(isCorrect && page == 4);
     }
 }
-
-#endif // GEODE_IS_ANDROID

--- a/src/hooks/more_options_layer.hpp
+++ b/src/hooks/more_options_layer.hpp
@@ -3,9 +3,6 @@
 
 #include <Geode/modify/MoreOptionsLayer.hpp>
 
-#ifdef GEODE_IS_ANDROID
-#ifndef GEODE_IS_IOS
-
 struct GLOBED_DLL HookedMoreOptionsLayer : geode::Modify<HookedMoreOptionsLayer, MoreOptionsLayer> {
     struct Fields {
         Ref<CCMenuItemSpriteExtra> adminBtn = nullptr;
@@ -17,5 +14,3 @@ struct GLOBED_DLL HookedMoreOptionsLayer : geode::Modify<HookedMoreOptionsLayer,
     $override
     void goToPage(int x);
 };
-
-#endif // GEODE_IS_ANDROID

--- a/src/hooks/more_options_layer.hpp
+++ b/src/hooks/more_options_layer.hpp
@@ -4,6 +4,7 @@
 #include <Geode/modify/MoreOptionsLayer.hpp>
 
 #ifdef GEODE_IS_ANDROID
+#ifndef GEODE_IS_IOS
 
 struct GLOBED_DLL HookedMoreOptionsLayer : geode::Modify<HookedMoreOptionsLayer, MoreOptionsLayer> {
     struct Fields {


### PR DESCRIPTION
Removed the `#ifdef GEODE_IS_ANDROID` in the `more_options_layer.cpp` so it works for both android and ios. (and also works in all platform cuz i basically made it worked in all platform when removing that def. Also added ios build flow.